### PR TITLE
Separate header cell class with body cell class

### DIFF
--- a/packages/react-data-grid/src/HeaderCell.js
+++ b/packages/react-data-grid/src/HeaderCell.js
@@ -109,7 +109,7 @@ class HeaderCell extends React.Component {
       'react-grid-HeaderCell--resizing': this.state.resizing,
       'react-grid-HeaderCell--locked': this.props.column.locked
     });
-    className = joinClasses(className, this.props.className, this.props.column.cellClass);
+    className = joinClasses(className, this.props.className, this.props.column.headerClass);
     let cell = this.getCell();
     return (
       <div className={className} style={this.getStyle()}>


### PR DESCRIPTION
To allow customize of different css between header and body class

## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
- Current whatever apply onto the cellClass css will apply to both header and child class


**What is the new behavior?**
by providing separation of css, header can obtain its own class 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
